### PR TITLE
[PDMO-63]-Improve error message on Observations page

### DIFF
--- a/app/js/components/obs.jsx
+++ b/app/js/components/obs.jsx
@@ -324,10 +324,10 @@ export default class Obs extends React.Component {
       questionError: ''
     })
     if(!this.refs.typeahead.state.query) {
-      this.setState({ questionError: "Question can not be empty or null" })
+      this.setState({ questionError: "Question can not be empty" })
     }
     if(!this.state.value) {
-      this.setState({ answerError: "Answer can not be empty or null" })
+      this.setState({ answerError: "Answer can not be empty " })
     }
     if(!this.state.answerError && !this.state.questionError) {
       if(Object.keys(this.state.editValues).length > 0) {


### PR DESCRIPTION
## JIRA TICKET NAME: 

[PDMO-63 Improve error message on Observations page](https://issues.openmrs.org/browse/PDMO-63)

## SUMMARY:
Currently when a user edits the observations page and submits with an empty Question Concept or Answer Concept field, the field gets highlighted with the message Question/Answer cannot be empty or null.(respectively)
The end user may not understand what 'null' means.
Correct the message to read Question/Answer cannot be empty (respectively)