### PR TITLE
PDMO-69: Correct manage encounters observations display

### DIFF
--- a/app/css/obsadmin.css
+++ b/app/css/obsadmin.css
@@ -545,11 +545,12 @@ a{
 }
 
 .encounter-header {
-    text-align: center;
+    text-align: left;
     color: #fff;
-    background: #363463;
+    background-color: #00463f;
     min-height: 35px;
     padding-top: 1%;
+   text-indent: 50px;
     margin-bottom: 3%
 }
 
@@ -727,4 +728,25 @@ li>a:hover {
 
 .thead{
   text-align: center;
+}
+#move-encounter{
+  width: fit-content;
+}
+
+input[type="radio"]{
+  margin: 4px 30px 0;
+}
+
+#accordion{
+  width: 100%;
+}
+
+.table-striped{
+  margin-left: 2%;
+}
+
+#show-deleted{
+  margin-left:80%;
+  justify-content: space-between;
+  font-size: 600;
 }

--- a/app/js/components/encounters/encounterForm.jsx
+++ b/app/js/components/encounters/encounterForm.jsx
@@ -25,11 +25,12 @@ const Encounter = (props) => {
     encounterData,
     editValues,
     editErrors,
+    moveChecked
   } = props.stateData;
 
   let editErrorClass = '';
   let editError = '';
-  if(editErrors.error.length > 0) {
+  if (editErrors.error.length > 0) {
     editErrorClass = 'has-error';
     editError = editErrors.error;
   }
@@ -40,37 +41,17 @@ const Encounter = (props) => {
   const encounterDatetime = moment(encounterData.encounterDatetime).format('YYYY-MM-DD HH:mm:ss');
   const voided = encounterData.voided;
 
-  return(
+  return (
     <div className="encounter">
       <form className="encounter-form">
         <div className="form-group row">
           <div className="col-sm-3">
-            {moveEncounter &&
-              <button
-                type="button"
-                name="update"
-                data-toggle="modal"
-                data-target="#myModal"
-                className="btn btn-success btn-move form-control"
-              >
-                Confirm Move</button>
-            }
-            {!moveEncounter &&
-              <button
-                type="button"
-                name="moveEncounter"
-                onClick={props.handleFieldEdits}
-                className="btn btn-success form-control btn-move"
-                disabled={voided || editable}
-              >
-                Move Encounter</button>
-            }
           </div>
           {voided &&
-           <div className="deleted">
-             <span className="badge badge-error">Deleted</span>
-           </div>
-         }
+            <div className="deleted">
+              <span className="badge badge-error">Deleted</span>
+            </div>
+          }
         </div>
 
         <div className="form-group row">
@@ -86,7 +67,7 @@ const Encounter = (props) => {
                 disabled={!moveEncounter}
                 onChange={props.handleSearchPatient}
               />
-              {((moveEncounter) && searchedPatients.length > 0) &&
+              {(moveEncounter && searchedPatients.length > 0) &&
                 <div className="dropdown-menu" id="selectedPatient">
                   {
                     searchedPatients.map((patient, index) => (
@@ -118,8 +99,13 @@ const Encounter = (props) => {
               onChange={props.handleChange}
             >
               {
-                locationArray.map(locations => (
-                  <option key={locations.uuid} value={locations.uuid}>{locations.display}</option>
+                locationArray.map(location => (
+                  <option
+                    key={location.uuid}
+                    value={location.uuid}
+                  >
+                    {location.display}
+                  </option>
                 ))
               }
             </select>
@@ -199,7 +185,7 @@ const Encounter = (props) => {
         </div>
 
         <div className="form-group row">
-          <label className="col-sm-4 col-form-label">Created By:</label>
+          <label className="col-sm-4 col-form-label">Created By: </label>
           <div className="col-sm-8">
             <input
               className="form-control"
@@ -208,6 +194,33 @@ const Encounter = (props) => {
               value={creator}
               disabled
             />
+          </div>
+        </div>
+
+        <div className="form-group row">
+          <label className="col-sm-4 col-form-label"> Move Encounter: </label>
+          <div id="move-encounter" className="col-sm-4">
+            <input
+              name="move"
+              className="form-check-input"
+              type="radio"
+              id="no"
+              checked={!moveEncounter}
+              onChange={props.handleFieldEdits}
+              disabled={voided}
+            />
+            <label for="no">NO</label>
+
+            <input
+              name="move"
+              className="form-check-input"
+              type="radio"
+              id="yes"
+              checked={moveEncounter}
+              onChange={props.handleFieldEdits}
+              disabled={voided}
+            />
+            <label for="yes">YES</label>
           </div>
         </div>
         {
@@ -229,7 +242,18 @@ const Encounter = (props) => {
 
         <div id="button" className="form-group row">
           <div className="col-sm-3">
-            {editable &&
+            {moveEncounter &&
+              <button
+                type="button"
+                name="update"
+                data-toggle="modal"
+                data-target="#myModal"
+                className="btn btn-success form-control"
+              >
+                Confirm Move</button>
+            }
+
+            {editable && !moveEncounter &&
               <button
                 type="button"
                 name="update"
@@ -240,7 +264,7 @@ const Encounter = (props) => {
                 Update</button>
             }
 
-            {!editable &&
+            {!editable && !moveEncounter &&
               <button
                 type="submit"
                 name="edit"
@@ -256,11 +280,15 @@ const Encounter = (props) => {
             <button
               type="button"
               name="cancel"
-              onClick={(editable || voided || moveEncounter) ? props.handleCancel : props.handleDelete}
+              onClick={
+                (editable || voided || moveEncounter)
+                  ? props.handleCancel
+                  : props.handleDelete}
               className="btn btn-danger form-control cancelBtn"
               disabled={(voided === true)}
             >
-              {(editable || voided || moveEncounter) ? 'Cancel' : 'Delete'}</button>
+              {(editable || voided || moveEncounter) ? 'Cancel' : 'Delete'}
+            </button>
           </div>
         </div>
       </form>
@@ -269,15 +297,20 @@ const Encounter = (props) => {
         <div className="modal-dialog">
           <div className="modal-content">
             <div className="modal-header">
-              <button type="button" className="close" data-dismiss="modal">&times;</button>
+              <button
+                type="button"
+                className="close"
+                data-dismiss="modal"
+              >
+                &times;
+              </button>
               <h4 className="modal-title">Confirm Edit</h4>
             </div>
             <div className="modal-body">
-              {(prevPatient === null || prevPatient === editValues.patientName) &&
-                <p> Are you sure want to edit this encounter?</p>
-              }
-              {(prevPatient !== editValues.patientName && prevPatient !== null) &&
-                <p> Are you sure want to move encounter from {prevPatient} to {editValues.patientName} </p>
+              {(moveEncounter) ?
+                <p> Are you sure you want to move encounter from {prevPatient} </p>
+                :
+                <p> Are you sure you want to edit this encounter?</p>
               }
             </div>
             <div className="modal-footer">
@@ -285,7 +318,10 @@ const Encounter = (props) => {
                 <button
                   type="button"
                   className="btn btn-success form-control"
-                  onClick={moveEncounter ? (e => props.handleUpdateNewPatient(e)) : (e => props.handleUpdateCurrentPatient(e))}
+                  onClick={
+                    moveEncounter ?
+                      (e => props.handleUpdateNewPatient(e))
+                      : (e => props.handleUpdateCurrentPatient(e))}
                   data-dismiss="modal"
                 >Confirm
                 </button>
@@ -317,4 +353,5 @@ Encounter.propTypes = {
   handleDelete: PropTypes.func,
   handleFieldEdits: PropTypes.func,
 };
+
 export default Encounter;

--- a/app/js/components/encounters/encountersParent.jsx
+++ b/app/js/components/encounters/encountersParent.jsx
@@ -147,8 +147,10 @@ export default class Encounters extends React.Component {
       }),
     }, function () {
       this.setState({ editErrors: { error: '' } });
-      if (((this.state.prevPatient === this.state.editValues.patientName) ||
-        this.state.prevPatient === null || this.state.editValues.patientName === '') || (/\s/g.test(searchValue))) {
+      if (((this.state.prevPatient === this.state.editValues.patientName)
+        || this.state.prevPatient === null
+        || this.state.editValues.patientName === '')
+        || (/\s/g.test(searchValue))) {
         this.setState({ editErrors: { error: 'No new patient detected' } });
       }
     });
@@ -186,8 +188,8 @@ export default class Encounters extends React.Component {
   }
 
   handleFieldEdits(event) {
-    event.preventDefault();
     const eventTargetName = event.target.name;
+    const eventTargetId = event.target.id;
     const providers = this.state.encounterData.encounterProviders;
     const patientName = this.state.encounterData.patient && this.state.encounterData.patient.display.split('-')[1];
     if (providers.length > 0) {
@@ -196,10 +198,16 @@ export default class Encounters extends React.Component {
           editable: true,
           prevPatient: patientName,
         })
-        : this.setState({
-          moveEncounter: true,
-          prevPatient: patientName,
-        });
+        : (eventTargetId === 'yes') ?
+          this.setState({
+            moveEncounter: true,
+            prevPatient: patientName,
+          })
+          :
+          this.setState({
+            moveEncounter: false,
+            prevPatient: patientName,
+          })
     } else {
       toastr.error('At least one provider is required');
     }
@@ -243,7 +251,7 @@ export default class Encounters extends React.Component {
       .catch(error => toastr.error(error));
   }
 
-  handleUpdateNewPatient(event) {
+  handleUpdateNewPatient() {
     event.preventDefault();
     this.setState({ editErrors: { error: '' } });
     if ((this.state.prevPatient === this.state.editValues.patientName) ||
@@ -409,7 +417,7 @@ export default class Encounters extends React.Component {
             <div className="col-sm-1">
             </div>
             <header className="encounter-header">
-              Encounter on {this.state.encounterDatetime}
+              Encounter
             </header>
             <div className="display">
               <Encounter


### PR DESCRIPTION
# JIRA TICKET NAME:

PDMO-69 [Manage Encounters UI redesign](https://issues.openmrs.org/browse/PDMO-69)

# SUMMARY: 
Currently we have tabs showing deleted observations and non deleted ones. This has been replaced by including a checkbox to show deleted. We have also used collapsible to show observations with group members. For move encounter, we have changed from button to radio buttons, this reduces the many  confusing buttons in the page.

