### PR TITLE
[PDMO-72]:Divide up the display of encounters and visits

### DIFF
--- a/app/css/obsadmin.css
+++ b/app/css/obsadmin.css
@@ -717,3 +717,14 @@ li>a:hover {
   width: 50%;
   float: right;
 }
+
+.rt-thead {
+    background: white;
+    color: black;
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+
+.thead{
+  text-align: center;
+}

--- a/app/js/components/visitsAndEncounters.jsx
+++ b/app/js/components/visitsAndEncounters.jsx
@@ -9,9 +9,23 @@
 import React from 'react';
 import toastr from 'toastr';
 import apiCall from '../utilities/apiHelper';
-import { TabContent, TabPane, Nav, NavItem, NavLink, Card, Button, CardTitle, CardText, Row, Col, Table } from 'reactstrap';
+import {
+  TabContent,
+  TabPane,
+  Nav,
+  NavItem,
+  NavLink,
+  Card,
+  Button,
+  CardTitle,
+  CardText,
+  Row,
+  Col,
+  Table
+} from 'reactstrap';
 import classnames from 'classnames';
-import { withRouter } from 'react-router'
+import { withRouter } from 'react-router';
+import ReactTable from 'react-table';
 
 export class VisitsAndEncounters extends React.Component {
   constructor(props) {
@@ -20,8 +34,7 @@ export class VisitsAndEncounters extends React.Component {
       uuid: this.props.uuid,
       visits: [],
       encounters: {},
-      showEncounters: {
-      },
+      showEncounters: {},
       encounterSource: "visit",
       encountersWithNoVisits: [],
       activeTab: '1'
@@ -34,11 +47,12 @@ export class VisitsAndEncounters extends React.Component {
     this.handleEncountersWithNoVisits = this.handleEncountersWithNoVisits.bind(this)
     this.handleEncountersWithVisits = this.handleEncountersWithVisits.bind(this)
     this.toggle = this.toggle.bind(this);
+    this.getAllEncounters = this.getAllEncounters.bind(this);
 
   }
 
   toggle(tab) {
-    if (this.state.activeTab !== tab) {
+    if(this.state.activeTab !== tab) {
       this.setState({
         activeTab: tab
       });
@@ -46,7 +60,7 @@ export class VisitsAndEncounters extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.state.uuid !== this.props.uuid) {
+    if(this.state.uuid !== this.props.uuid) {
       this.setState({
         uuid: this.props.uuid
       });
@@ -60,9 +74,9 @@ export class VisitsAndEncounters extends React.Component {
         const getVisits = visits.map(visit => apiCall(null, 'get', `/visit/${visit.uuid}`))
 
         return Promise.all(getVisits).then(data => {
-          this.setState({ visits: data, encounters: this.handleData(data) });
-          return data;
-        })
+            this.setState({ visits: data, encounters: this.handleData(data) });
+            return data;
+          })
           .catch(error => toastr.error(error));
       })
       .catch(error => toastr.error(error));
@@ -94,8 +108,7 @@ export class VisitsAndEncounters extends React.Component {
         }
       }),
 
-    })
-    )
+    }))
   }
 
   handleShowLess(encounter, id) {
@@ -124,9 +137,47 @@ export class VisitsAndEncounters extends React.Component {
     this.setState({ encounterSource: "visit" });
   }
 
-  render() {
+  getAllEncounters() {
+    let data = {}
+    let output = []
+    this.state.visits.map((visit) => {
+      visit.encounters.map((encounter) => {
+        data["visit"] = visit.visitType.display
+        data["location"] = visit.location.display
+        data["date"] = visit.startDatetime
+        data["encounter"] = encounter.display
+        data["visitUuid"] = visit.uuid
+        data["encounterUuid"] = encounter.uuid
+        output.push(data)
+        data = []
+      })
+    })
+    return output
+  }
 
-    return (
+  render() {
+    const columns = [{
+        id: 'type',
+        Header: 'Type',
+        accessor: rowProps => <a>{rowProps.encounter.slice(0, -10)}</a>,
+      },
+      {
+        id: 'location',
+        Header: 'Location',
+        accessor: rowProps => rowProps.location,
+      },
+      {
+        id: 'date',
+        Header: 'Date',
+        accessor: rowProps => rowProps.date.split("T")[0],
+      },
+      {
+        id: 'visit',
+        Header: 'Visit',
+        accessor: rowProps => <a>{rowProps.visit}</a>,
+      }
+    ];
+    return(
       <div>
         <Nav tabs >
           <NavItem>
@@ -134,7 +185,7 @@ export class VisitsAndEncounters extends React.Component {
               className={classnames({ active: this.state.activeTab === '1' })}
               onClick={() => { this.toggle('1'); }}
             >
-              Encounters With Visits
+              Visits
             </NavLink>
           </NavItem>
           <NavItem>
@@ -142,7 +193,7 @@ export class VisitsAndEncounters extends React.Component {
               className={classnames({ active: this.state.activeTab === '2' })}
               onClick={() => { this.toggle('2'); }}
             >
-              Encounters Without Visits
+              Encounters
             </NavLink>
           </NavItem>
         </Nav>
@@ -150,14 +201,12 @@ export class VisitsAndEncounters extends React.Component {
           <TabPane tabId="1">
             <Row>
               <Col sm="12">
-                <Table hover>
+                <Table hover striped>
                   <thead>
                     <tr>
-                      <th>Visit Type</th>
-                      <th>Location</th>
-                      <th>Start Date</th>
-                      <th>Stop Date</th>
-                      <th>Encounters</th>
+                      <th className="thead">Date</th>
+                      <th className="thead">Visit</th>
+                      <th className="thead">Location</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -165,28 +214,18 @@ export class VisitsAndEncounters extends React.Component {
                       const showEncounter = this.state.showEncounters[visit.uuid]
                       const endIndex = showEncounter ? showEncounter.length : 3;
                       return (
-                        <tr id="custom-a-tag" key={visit.uuid}>
-                          <a><td name="visituuid" onClick={() => this.handleVisitClick(visit.uuid)} value={visit.uuid}>{visit.display}</td></a>
-                          <td>{visit.location.display}</td>
-                          <td>{new Date(visit.startDatetime).toString()}</td>
-                          <td>{new Date(visit.stopDatetime).toString()}</td>
-                          <a><td>{this.state.encounters[visit.uuid].slice(0, endIndex).map(encounter => (
-                            (encounter.voided) ?
-                              <del><li name="encounteruuid" onClick={() => this.handleEncounterClick(encounter.uuid)} value={encounter.uuid}>{encounter.display}</li></del>
-                              : <li name="encounteruuid" onClick={() => this.handleEncounterClick(encounter.uuid)} value={encounter.uuid}>{encounter.display}</li>
-                          ))
-                          }
-                            {(this.state.encounters[visit.uuid].length > 3 && !showEncounter)
-                              ? <a id="bolded-a-tag" onClick={() => this.handleShowMore(this.state.encounters[visit.uuid], visit.uuid)}>
-                                Show More!
-                              </a>
-                              : (showEncounter) ? <a id="bolded-a-tag" onClick={() => this.handleShowLess(this.state.encounters[visit.uuid], visit.uuid)}>
-                                Show Less!
-                              </a>
-                                : ''
-                            }
+                        <tr id="custom-a-tag" key={visit.uuid} className="thead">
+                          <td className="thead">
+                            {visit.startDatetime.split("T")[0]}
+                          </td>
+                          <td className="thead"
+                              name="visituuid"
+                              onClick={() => this.handleVisitClick(visit.uuid)}
+                              value={visit.uuid}>
+                              <a>{visit.display.split("@")[0]}</a>
+                          </td>
+                          <td className="thead">{visit.location.display}</td>
 
-                          </td></a>
                         </tr>
                       )
                     }
@@ -199,36 +238,31 @@ export class VisitsAndEncounters extends React.Component {
           <TabPane tabId="2">
             <Row>
               <Col sm="12">
-                <Table hover>
-                  <thead>
-                    <tr>
-                      <th>Encounter</th>
-                      <th>Location</th>
-                      <th>Encounter Date</th>
-                      <th>Form</th>
-                    </tr>
-                  </thead>
-                  {this.state.encountersWithNoVisits.length > 0 ?
-                    <tbody>
-                      {this.state.encountersWithNoVisits.map((encounter) => {
-
-                        return (
-                          <tr key={encounter.uuid}>
-                            <a><td name="encounteruuid" onClick={() => this.handleEncounterClick(encounter.uuid)} value={encounter.uuid}>{encounter.display}</td></a>
-                            <td>{encounter.location.display}</td>
-                            <td>{new Date(encounter.encounterDatetime).toString()}</td>
-                            <td>{encounter.form.display}</td>
-                          </tr>
-                        )
+              <ReactTable
+                className="-striped -highlight"
+                data={this.getAllEncounters()}
+                pageSize= {this.getAllEncounters().length}
+                columns={columns}
+                showPageSizeOptions={false}
+                getTdProps={(state, rowInfo, column, instance) => {
+                  return {
+                    onClick: (e, handleOriginal) => {
+                      if(column.Header === "Visit"){
+                        this.handleVisitClick(rowInfo.original.visitUuid)
+                        if (handleOriginal) {
+                          handleOriginal()
+                        }
                       }
-                      )}
-                    </tbody>
-                    :
-                    <tbody>
-                      <h4>There are no encounters with out visits</h4>
-                    </tbody>
+                      if(column.Header === "Type"){
+                        this.handleEncounterClick(rowInfo.original.encounterUuid)
+                        if (handleOriginal) {
+                          handleOriginal()
+                        }
+                      }
+                    }
                   }
-                </Table>
+                }}
+              />
               </Col>
             </Row>
           </TabPane>


### PR DESCRIPTION
## JIRA TICKET NAME:

[PDMO-72 Divide up the display of encounters and visits](https://issues.openmrs.org/browse/PDMO-72)

## SUMMARY:
Create two separate tables in the existing tabs to display visits and encounters in reverse chronological order instead of displaying them under one table