### PR TITLE
[PDMO-95]-Change the mouse from Input to cursor when hovering over breadcrumbs

### DIFF
--- a/app/css/obsadmin.css
+++ b/app/css/obsadmin.css
@@ -851,6 +851,10 @@ input[type="radio"]{
   text-decoration: line-through;
 }
 
+.breadcrumb{
+  cursor: pointer;
+}
+
 .dateField{
   flex: 100 0 auto;
   width: 100%;


### PR DESCRIPTION
## JIRA TICKET NAME:

[PDMO-95 Change the mouse from Input to cursor when hovering over breadcrumbs](https://issues.openmrs.org/browse/PDMO-95)

## SUMMARY:
Currently on hovering over the breadcrumbs the mouse is of input type this should indicate a cursor so as to indicate that this are clickable.